### PR TITLE
Add Docker Secrets support and bump version to 1.2.3

### DIFF
--- a/src/Oip.Settings/BaseAppSettings.cs
+++ b/src/Oip.Settings/BaseAppSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using Mcrio.Configuration.Provider.Docker.Secrets;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -206,6 +207,7 @@ public class BaseAppSettings<TAppSettings> : IAppSettings where TAppSettings : c
             .AddJsonFile(_appSettingsOptions.JsonFileName, optional: true, reloadOnChange: true)
             .AddJsonFile(_appSettingsOptions.JsonFileNameDevelopment, optional: true, reloadOnChange: true)
             .AddUserSecrets<TAppSettings>()
+            .AddDockerSecrets()
             .AddSpaConfig()
             .AddModuleConfig()
             .AddEnvironmentVariables()

--- a/src/Oip.Settings/Oip.Settings.csproj
+++ b/src/Oip.Settings/Oip.Settings.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
-        <Version>1.2.1</Version>
+        <Version>1.2.3</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -40,6 +40,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0"/>
+        <PackageReference Include="Mcrio.Configuration.Provider.Docker.Secrets" Version="1.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Oip.Settings/README.md
+++ b/src/Oip.Settings/README.md
@@ -4,7 +4,9 @@ Application settings with EFCore provider with priority:
 
 * Command line argument
 * Environment variables
-* Json file
+* JSON files
+* User secret
+* Docker secret
 * EF Core
 
 # Startup


### PR DESCRIPTION
1. Add Mcrio.Configuration.Provider.Docker.Secrets package reference
2. Integrate Docker secrets provider into configuration builder pipeline
3. Update README documentation to include Docker secrets
4. Increment package version from 1.2.1 to 1.2.3