### PR TITLE
Update package versions and add multi-target framework support

### DIFF
--- a/src/Oip.Settings.Tests/Oip.Settings.Tests.csproj
+++ b/src/Oip.Settings.Tests/Oip.Settings.Tests.csproj
@@ -9,13 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.22"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.22"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.22"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.22"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.22"/>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.22"/>
+
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
         <PackageReference Include="NUnit" Version="4.4.0"/>
         <PackageReference Include="Moq" Version="4.20.72"/>

--- a/src/Oip.Settings.Tests/appsettings-sql-server.json
+++ b/src/Oip.Settings.Tests/appsettings-sql-server.json
@@ -1,3 +1,3 @@
 {
-  "ConnectionString": "XpoProvider=MSSqlServer;Server=localhost;Database=oip-test;uid=sa;pwd=P@ssw0rd;"
+  "ConnectionString": "XpoProvider=MSSqlServer;Server=localhost;Database=oip-test;uid=sa;pwd=P@ssw0rd;TrustServerCertificate=true"
 }

--- a/src/Oip.Settings/Oip.Settings.csproj
+++ b/src/Oip.Settings/Oip.Settings.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
-        <Version>1.2.3</Version>
+        <Version>1.2.4</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Oip.Settings/Oip.Settings.csproj
+++ b/src/Oip.Settings/Oip.Settings.csproj
@@ -27,19 +27,35 @@
         <None Include=".\README.md" Pack="true" PackagePath="\"/>
     </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.22"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.22"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.22"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.22"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.22"/>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.22"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0"/>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.36"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.36"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.36"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.36"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.36"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.29"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.2"/>
+        <PackageReference Include="Mcrio.Configuration.Provider.Docker.Secrets" Version="1.0.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.22"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.22"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.22"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.22"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1"/>
         <PackageReference Include="Mcrio.Configuration.Provider.Docker.Secrets" Version="1.0.1" />
     </ItemGroup>
 


### PR DESCRIPTION
- Update EF Core and related packages to latest versions for net6.0 and net8.0
- Add conditional package references for different target frameworks
- Clean up test project dependencies and remove unused packages
- Add TrustServerCertificate=true to SQL Server connection string in tests